### PR TITLE
added cs translation, cache thumbnails file format changed from PNG to JPG

### DIFF
--- a/core/components/cliche/controllers/web/plugins/default/default.class.php
+++ b/core/components/cliche/controllers/web/plugins/default/default.class.php
@@ -133,7 +133,7 @@ class DefaultPlugin extends ClichePlugin {
     public function setItemPlaceholder($phs, $obj){
         /* We use the internal phpThumb class to set the custom thumbnail */
         $fileName = str_replace(' ', '_', $obj->get('name'));
-        $mask = $fileName .'-'. $phs['width'] .'x'. $phs['height'] .'-zc.png';
+        $mask = $fileName .'-'. $phs['width'] .'x'. $phs['height'] .'-zc.jpg';
         $file = $obj->getCacheDir() . $mask;
         if(!file_exists($file)){
             $original = $this->controller->config['images_path'] . $obj->get('filename');
@@ -142,7 +142,7 @@ class DefaultPlugin extends ClichePlugin {
                 'jpegQuality' => 90,
              ));
             $thumb->adaptiveResize($phs['width'], $phs['height']);
-            $thumb->save($file, 'png');
+            $thumb->save($file, 'jpg');
         }
         $phs['thumbnail'] = $obj->getCacheDir(false) . $mask;
         

--- a/core/components/cliche/lexicon/cs/mgr.inc.php
+++ b/core/components/cliche/lexicon/cs/mgr.inc.php
@@ -160,3 +160,10 @@ $_lang['cliche.no_desc'] = '<em>Bez popisu</em>';
 $_lang['cliche.no_preview'] = 'Bez náhledu';
 // $_lang['cliche.saving_msg'] = 'Saving, please Wait...';
 $_lang['cliche.saving_msg'] = 'Ukládání, momentíček...';
+// $_lang['cliche.save_new_order'] = 'Save new order';
+$_lang['cliche.save_new_order'] = 'Uložit nové pořadí';
+
+
+/* AlbumSelect TV */
+// $_lang['cliche.album_management'] = 'Manage album';
+$_lang['cliche.album_management'] = 'Spravovat album';


### PR DESCRIPTION
added cs translation, but found some other texts not included in translation lexicons:

/assets/components/cliche/mgr/core/album.js:

```
        title: 'Reorder album'
        ,text: 'Are sure you want to reorder this album item\'s ?'
```
